### PR TITLE
Added CLI swithces for forcing selection of separator (-c - comma, -t…

### DIFF
--- a/include/messages.h
+++ b/include/messages.h
@@ -6,6 +6,6 @@ void printHelp();
 void wrongUsage();
 void wrongFile(char* mode,char* path);
 
-int handleStartup(int argc,char** argv,int* optind_);
+int handleStartup(int argc,char** argv,int* optind_,char* separator);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,7 @@
  * Simple CLI utility for extraction of XRD data from XRDML format into CSV compatible (or into other ASCII based format).
  * Author: mgr inż. Aleksander Szpakiewicz-Szatan
  * (c) 2021-2022
- * version alpha-1.7c
+ * version beta-1.0
  */ 
 
 #include <stdio.h>
@@ -18,9 +18,10 @@ int main(int argc,char** argv)
 {
 	int optind=0;
 	int err;
+	char separator=',';
 	
 	//Handle CLI switches, print help, GNU Notice...
-	err=handleStartup(argc,argv,&optind);
+	err=handleStartup(argc,argv,&optind,&separator);
 	if(err!=0)
 		return err;
 	
@@ -35,7 +36,7 @@ int main(int argc,char** argv)
 	//prepare input buffer
 	char buffer[255];
 	char* ptr;
-	char separator=',';
+	
 	
 	long double start,stop;
 	while(!feof(fileIn))

--- a/src/messages.c
+++ b/src/messages.c
@@ -33,6 +33,10 @@ void printHelp()
 	fprintf(stdout,"xrdml2xy [-h]\n");
 	fprintf(stdout,"-s - prevents display of GNU License Notice (silent).\n");
 	fprintf(stdout,"-h, -? - displays this help.\n");
+	fprintf(stdout,"-c, force (default) comma \',\' as separator.\n");
+	fprintf(stdout,"-S, force semicolon \';\' as separator.\n");
+	fprintf(stdout,"-t, force tabulator \'\\t\' as separator.\n");
+	fprintf(stdout,"If more then one separator selecting switch is used, behaviour is undefined, probably based on order.\n");
 }
 
 //print if wrong number of parameters was used
@@ -47,12 +51,12 @@ void wrongFile(char* mode,char* path)
 	fprintf(stderr,"Could not open file for %s: %s\n",mode,path);
 }
 
-int handleStartup(int argc,char** argv,int* optind_)
+int handleStartup(int argc,char** argv,int* optind_,char* separator)
 {
 	uint_fast8_t notice=1,help=0;
 	char cc;
 	//Detect cli switches and set proper flags
-	while((cc=getopt(argc,argv,":sh"))!=-1)
+	while((cc=getopt(argc,argv,":shctS"))!=-1)
 	{	
 		switch(cc)
 		{
@@ -65,15 +69,21 @@ int handleStartup(int argc,char** argv,int* optind_)
 			case 's':
 				notice=0;
 				break;
+				
+			//force ',' as separator
+			case 'c':
+				*separator=',';
+				break;
+			//force '\t' as separator
+			case 't':
+				*separator='\t';
+				break;
+			case 'S':
+				*separator=';';
+				break;
 		}
 	}
     *optind_=optind;
-    //Detect if proper number of arguments are present
-	if(argc-optind!=2)
-	{
-		wrongUsage();
-		return 1;
-	}
 	
 	//Print notice about GPL
 	if(notice)
@@ -85,5 +95,13 @@ int handleStartup(int argc,char** argv,int* optind_)
 		printHelp();
 		return -1;
 	}
+	
+	//Detect if proper number of arguments are present
+	if(argc-optind!=2)
+	{
+		wrongUsage();
+		return 1;
+	}
+	
 	return 0;
 }


### PR DESCRIPTION
… - tabulator, -S - semicolon). Fixed order of messages, as using -h without filenames resulted in not printing help.

Moving to beta, as all main features are implemented.